### PR TITLE
Path-related tests fail on Linux

### DIFF
--- a/src/NUnitCore/core/AssemblyHelper.cs
+++ b/src/NUnitCore/core/AssemblyHelper.cs
@@ -53,18 +53,16 @@ namespace NUnit.Core
             // Skip over the file:// part
             int start = Uri.UriSchemeFile.Length + Uri.SchemeDelimiter.Length;
 
-            bool isWindows = System.IO.Path.DirectorySeparatorChar == '\\';
-
             if (codeBase[start] == '/') // third slash means a local path
             {
                 // Handle Windows Drive specifications
-                if (isWindows && codeBase[start + 2] == ':')
+                if (codeBase[start + 2] == ':')
                     ++start;  
                 // else leave the last slash so path is absolute  
             }
             else // It's either a Windows Drive spec or a share
             {
-                if (!isWindows || codeBase[start + 1] != ':')
+                if (codeBase[start + 1] != ':')
                     start -= 2; // Back up to include two slashes
             }
 

--- a/src/NUnitFramework/framework/Constraints/PathConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/PathConstraint.cs
@@ -14,8 +14,10 @@ namespace NUnit.Framework.Constraints
 	/// that operate on paths and provides several helper methods.
 	/// </summary>
 	public abstract class PathConstraint : Constraint
-	{
-        private static readonly char[] DirectorySeparatorChars = new char[] { '\\', '/' };
+    {
+        private const char WindowsDirectorySeparatorChar = '\\';
+        private const char NonWindowsDirectorySeparatorChar = '/';
+        private static readonly char[] DirectorySeparatorChars = { WindowsDirectorySeparatorChar, NonWindowsDirectorySeparatorChar };
 
 		/// <summary>
 		/// The expected path used in the constraint
@@ -25,7 +27,7 @@ namespace NUnit.Framework.Constraints
         /// <summary>
         /// Flag indicating whether a caseInsensitive comparison should be made
         /// </summary>
-        protected bool caseInsensitive = Path.DirectorySeparatorChar == '\\';
+        protected bool caseInsensitive = Path.DirectorySeparatorChar == WindowsDirectorySeparatorChar;
 
         /// <summary>
 		/// Construct a PathConstraint for a give expected path
@@ -95,8 +97,10 @@ namespace NUnit.Framework.Constraints
             string leadingSeparators = "";
             foreach (char c in path)
             {
-                if (c == Path.DirectorySeparatorChar)
-                    leadingSeparators += c;
+                if (c == WindowsDirectorySeparatorChar || c == NonWindowsDirectorySeparatorChar)
+                {
+                    leadingSeparators += Path.DirectorySeparatorChar;
+                }
                 else break;
             }
 


### PR DESCRIPTION
Fixes #14, Backport nunit/nunit#83

This didn't have any tests, but it was a straight backport and all v2 tests pass.
