### PR TITLE
Do not run Nunit 3.0 tests

### DIFF
--- a/src/NUnitCore/core/Builders/TestAssemblyBuilder.cs
+++ b/src/NUnitCore/core/Builders/TestAssemblyBuilder.cs
@@ -222,9 +222,10 @@ namespace NUnit.Core.Builders
             {
                 if((an.Name == "nunit.framework") && an.Version.Major > 2)
                 {
-                    log.Warning("Skipped loading assembly {0} because it references an unsupported version of the nunit.framework, {1}",
+                    string msg = string.Format("Skipped loading assembly {0} because it references an unsupported version of the nunit.framework, {1}",
                         assembly.GetName().Name, an.Version);
-                    return new ArrayList();
+                    log.Warning(msg);
+                    throw new UnsupportedFrameworkException(msg);
                 }
             }
 

--- a/src/NUnitCore/core/UnsupportedFrameworkException.cs
+++ b/src/NUnitCore/core/UnsupportedFrameworkException.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace NUnit.Core
+{
+    /// <summary>
+    /// Exception raised when loading a test assembly using
+    /// an unsupported version of the nunit framework
+    /// </summary>
+    [Serializable]
+    public class UnsupportedFrameworkException : ApplicationException
+    {
+        #region Constructors
+
+        public UnsupportedFrameworkException(string message)
+            : base(message) { }
+
+        protected UnsupportedFrameworkException(SerializationInfo info, StreamingContext context) 
+            : base(info, context) { }
+
+        #endregion
+    }
+}

--- a/src/NUnitCore/core/nunit.core.dll.csproj
+++ b/src/NUnitCore/core/nunit.core.dll.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
@@ -152,6 +152,7 @@
     <Compile Include="Builders\TestAssemblyBuilder.cs" />
     <Compile Include="Builders\TestCaseParameterProvider.cs" />
     <Compile Include="Builders\TestCaseSourceProvider.cs" />
+    <Compile Include="UnsupportedFrameworkException.cs" />
     <Compile Include="Builders\ValueSourceProvider.cs" />
     <Compile Include="ContextDictionary.cs" />
     <Compile Include="CoreExtensions.cs" />


### PR DESCRIPTION
I have removed the search for nunitlite and now throw a new `NUnit.Core.UnsupportedFrameworkException` if attempting to run a test assembly using NUnit 3.0 or newer. In the console and in the nunit.gui, this gets caught by the general exception block and displays the error. I made it a special exception so that the adapter can handle it differently if Terje chooses.

Fixes #30
