### PR TITLE
Corrected 'DataPoint' to 'Datapoint' in documentation

### DIFF
--- a/doc/datapoint.html
+++ b/doc/datapoint.html
@@ -31,7 +31,7 @@
    to provide data for <b>Theories</b> and are ignored for ordinary
    tests - including tests with parameters.
    
-<h4>DataPointAttribute</h4>
+<h4>DatapointAttribute</h4>
    
 <p>When a Theory is loaded, NUnit creates arguments for each
    of its parameters by using any fields of the same type
@@ -40,7 +40,7 @@
    and their Type must exactly match the argument for which
    data is being supplied.
    
-<h4>DataPointsAttribute</h4>
+<h4>DatapointsAttribute</h4>
    
 <p>In addition to specifying individual datapoints, collections of
    datapoints may be provided by use of the <b>DatapointsAttribute</b>


### PR DESCRIPTION
The attribute type names start with 'Datapoint', not 'DataPoint'.