### PR TITLE
NUnit 3 issue 681 fix back ported to NUnit 2

### DIFF
--- a/src/ClientUtilities/util/TestAssemblyDirectoryResolveHelper.cs
+++ b/src/ClientUtilities/util/TestAssemblyDirectoryResolveHelper.cs
@@ -1,0 +1,45 @@
+﻿// ****************************************************************
+// This is free software licensed under the NUnit license. You
+// may obtain a copy of the license as well as information regarding
+// copyright ownership at http://nunit.org
+// ****************************************************************
+
+using System;
+using System.Reflection;
+
+namespace NUnit.Util
+{
+    class TestAssemblyDirectoryResolveHelper
+    {
+        public static bool AssemblyNeedsResolver(string assemblyPath)
+        {
+            var domain = AppDomain.CreateDomain("TestAssemblyDirectoryResolveHelperCheckDomain");
+            try
+            {
+                var agentType = typeof(AttributeCheckAgent);
+                var agent = domain.CreateInstanceFromAndUnwrap(agentType.Assembly.CodeBase, agentType.FullName) as AttributeCheckAgent;
+                bool helperRequested = agent.HelperRequested(assemblyPath);
+                return helperRequested;
+                
+            }
+            finally
+            {
+                AppDomain.Unload(domain);
+            }
+        }
+
+        private class AttributeCheckAgent : MarshalByRefObject
+        {
+            private const string ATTRIBUTE = "NUnit.Framework.TestAssemblyDirectoryResolveAttribute";
+
+            public bool HelperRequested(string assemblyPath)
+            {
+                // You can't get custom attributes when the assembly is loaded reflection only
+                var testAssembly = Assembly.LoadFrom(assemblyPath);
+                var allAttrs = testAssembly.GetCustomAttributes(false);
+                bool hasAttr = Array.Exists(allAttrs, attr => attr.GetType().FullName == ATTRIBUTE);
+                return hasAttr;
+            }
+        }
+    }
+}

--- a/src/ClientUtilities/util/nunit.util.build
+++ b/src/ClientUtilities/util/nunit.util.build
@@ -36,6 +36,7 @@
     <include name="SettingsGroup.cs"/>
     <include name="SettingsStorage.cs"/>
     <include name="StackTraceFilter.cs"/>
+    <include name="TestAssemblyDirectoryResolveHelper.cs"/>
     <include name="TestDomain.cs"/>
     <include name="TestEventArgs.cs"/>
     <include name="TestEventDispatcher.cs" if="${runtime.version >= '2.0'}"/>

--- a/src/ClientUtilities/util/nunit.util.dll.csproj
+++ b/src/ClientUtilities/util/nunit.util.dll.csproj
@@ -160,6 +160,7 @@
     <Compile Include="SettingsGroup.cs" />
     <Compile Include="SettingsStorage.cs" />
     <Compile Include="StackTraceFilter.cs" />
+    <Compile Include="TestAssemblyDirectoryResolveHelper.cs" />
     <Compile Include="TestDomain.cs" />
     <Compile Include="TestEventArgs.cs" />
     <Compile Include="TestEventDispatcher.cs" />

--- a/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestAssemblyDirectoryResolveAttribute.cs
@@ -1,0 +1,21 @@
+﻿// ****************************************************************
+// This is free software licensed under the NUnit license. You
+// may obtain a copy of the license as well as information regarding
+// copyright ownership at http://nunit.org
+// ****************************************************************
+
+using System;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// TestAssemblyDirectoryResolveAttribute is used to mark a test assembly as needing a
+    /// special assembly resolution hook that will explicitly search the test assembly's
+    /// directory for dependent assemblies. This works around a conflict between mixed-mode
+    /// assembly initialization and tests running in their own AppDomain in some cases.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
+    public class TestAssemblyDirectoryResolveAttribute : Attribute
+    {
+    }
+}

--- a/src/NUnitFramework/framework/nunit.framework.build
+++ b/src/NUnitFramework/framework/nunit.framework.build
@@ -25,6 +25,7 @@
         <include name="Attributes/SuiteAttribute.cs"/>
         <include name="Attributes/TearDownAttribute.cs"/>
         <include name="Attributes/TestActionAttribute.cs"/>
+        <include name="Attributes/TestAssemblyDirectoryResolveAttribute.cs"/>
         <include name="Attributes/TestAttribute.cs"/>
         <include name="Attributes/TestCaseAttribute.cs"/>
         <include name="Attributes/TestCaseSourceAttribute.cs"/>

--- a/src/NUnitFramework/framework/nunit.framework.dll.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.dll.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Attributes\SuiteAttribute.cs" />
     <Compile Include="Attributes\TearDownAttribute.cs" />
     <Compile Include="Attributes\TestActionAttribute.cs" />
+    <Compile Include="Attributes\TestAssemblyDirectoryResolveAttribute.cs" />
     <Compile Include="Attributes\TestAttribute.cs" />
     <Compile Include="Attributes\TestCaseAttribute.cs" />
     <Compile Include="Attributes\TestCaseSourceAttribute.cs" />


### PR DESCRIPTION
I've backported to NUnit 2 a simple version of the fix for https://github.com/nunit/nunit/issues/681 using the same new assembly attribute from NUnit 3 (so code using this new behavior on NUnit 2 should port forward to NUnit 3 with no changes required, assuming the NUnit 3 implementation doesn't get reworked).

At my day job we have a large number of tests that run against NUnit 2 with no immediate plans to upgrade and so this version of the fix is most useful near term for my purposes -- I'm guessing some others are in the same boat given the maturity of all the tooling surrounding NUnit 2.

Submitting this PR in case you think it'd be appropriate to accept these changes upstream so that any custom builds including this fix can be based on the canonical nunitv2 repo.
